### PR TITLE
Paraguay Standard Time: PYT

### DIFF
--- a/timezones.json
+++ b/timezones.json
@@ -250,7 +250,7 @@
   },
   {
     "value": "Paraguay Standard Time",
-    "abbr": "PST",
+    "abbr": "PYT",
     "offset": -4,
     "isdst": false,
     "text": "(UTC-04:00) Asuncion",


### PR DESCRIPTION
PST is Pacific Standard Time while PYT is Paraguay Standard Time.

A person using PST as a means of correcting timezone offsets for a user would end up getting a -4:00 instead of -7:00 offset... which is pretty confusing :)

http://www.worldtimeserver.com/time-zones/pyt/